### PR TITLE
Feat: Implement secure WebSocket chat using HttpOnly Cookies.

### DIFF
--- a/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/configs/CookieHandshakeInterceptor.java
+++ b/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/configs/CookieHandshakeInterceptor.java
@@ -1,0 +1,57 @@
+package io.github.adrian.wieczorek.local_trade.configs;
+
+import io.github.adrian.wieczorek.local_trade.security.JwtService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CookieHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean beforeHandshake(@NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response,
+                                   @NonNull WebSocketHandler wsHandler, @NonNull Map<String, Object> attributes) {
+
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpServletRequest req = servletRequest.getServletRequest();
+
+            Optional.ofNullable(req.getCookies())
+                    .stream()
+                    .flatMap(Arrays::stream)
+                    .filter(cookie -> "accessToken".equals(cookie.getName()))
+                    .findFirst()
+                    .map(Cookie::getValue)
+                    .ifPresent(token -> {
+                        try {
+                            String email = jwtService.extractUsername(token);
+                            attributes.put("userEmail", email);
+                            log.info("Authorized web token for {}", email);
+                        } catch (Exception e) {
+                            log.warn("Not authorized for{}", e.getMessage());
+                        }
+                    });
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(@NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response,
+                               @NonNull WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/configs/CustomHandshakeHandler.java
+++ b/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/configs/CustomHandshakeHandler.java
@@ -1,0 +1,22 @@
+package io.github.adrian.wieczorek.local_trade.configs;
+
+import lombok.NonNull;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Optional;
+
+public class CustomHandshakeHandler extends DefaultHandshakeHandler {
+
+    @Override
+    protected Principal determineUser(@NonNull ServerHttpRequest request, @NonNull WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if (attributes.get("userEmail") instanceof String email) {
+            return new UsernamePasswordAuthenticationToken(email, null, null);
+        }
+        return null;
+    }
+}

--- a/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/configs/WebSocketConfiguration.java
+++ b/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/configs/WebSocketConfiguration.java
@@ -1,5 +1,6 @@
 package io.github.adrian.wieczorek.local_trade.configs;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -11,9 +12,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer {
-    private final UserChannelInterceptor userChannelInterceptor;
-    public WebSocketConfiguration(UserChannelInterceptor userChannelInterceptor) {
-        this.userChannelInterceptor = userChannelInterceptor;
+    private final CookieHandshakeInterceptor cookieHandshakeInterceptor;
+
+    @Value("${allowed.interceptor.origins}")
+    private String allowedInterceptorOrigins;
+
+    public WebSocketConfiguration(CookieHandshakeInterceptor cookieHandshakeInterceptor) {
+        this.cookieHandshakeInterceptor = cookieHandshakeInterceptor;
     }
 @Override
     public void configureMessageBroker(@NonNull MessageBrokerRegistry registry) {
@@ -22,15 +27,11 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     registry.setUserDestinationPrefix("/user");
 }
 
-@Override
-    public void registerStompEndpoints(@NonNull StompEndpointRegistry registry) {
-    registry.addEndpoint("/ws");
-    registry.addEndpoint("/ws").setAllowedOrigins("*").withSockJS();
-}
     @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(userChannelInterceptor);
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins(allowedInterceptorOrigins)
+                .addInterceptors(cookieHandshakeInterceptor)
+                .setHandshakeHandler(new CustomHandshakeHandler());
     }
-
-
 }

--- a/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/service/advertisement/service/AdvertisementFilterServiceImpl.java
+++ b/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/service/advertisement/service/AdvertisementFilterServiceImpl.java
@@ -66,7 +66,6 @@ public class AdvertisementFilterServiceImpl implements AdvertisementFilterServic
                     predicates.add(cb.equal(root.get("active"), filter.active()));
                 }
 
-
             return cb.and(predicates.toArray(new Predicate[0]));
         };
     }

--- a/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/service/advertisement/service/AdvertisementFinder.java
+++ b/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/service/advertisement/service/AdvertisementFinder.java
@@ -1,6 +1,5 @@
 package io.github.adrian.wieczorek.local_trade.service.advertisement.service;
 
-import io.github.adrian.wieczorek.local_trade.service.advertisement.AdvertisementEntity;
 import io.github.adrian.wieczorek.local_trade.service.advertisement.AdvertisementRepository;
 import io.github.adrian.wieczorek.local_trade.service.advertisement.dto.ResponseAdvertisementDto;
 import io.github.adrian.wieczorek.local_trade.service.advertisement.dto.SimpleAdvertisementResponseDto;

--- a/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/service/image/service/S3ServiceImpl.java
+++ b/services/main-api/src/main/java/io/github/adrian/wieczorek/local_trade/service/image/service/S3ServiceImpl.java
@@ -1,20 +1,15 @@
 package io.github.adrian.wieczorek.local_trade.service.image.service;
 
 import io.github.adrian.wieczorek.local_trade.service.advertisement.service.AdvertisementService;
-import io.github.adrian.wieczorek.local_trade.service.image.dto.ImageDto;
-import io.github.adrian.wieczorek.local_trade.service.image.mapper.ImageMapper;
 import io.github.adrian.wieczorek.local_trade.service.advertisement.AdvertisementEntity;
 import io.github.adrian.wieczorek.local_trade.service.image.ImageEntity;
-import io.github.adrian.wieczorek.local_trade.service.advertisement.AdvertisementRepository;
 import io.github.adrian.wieczorek.local_trade.service.image.ImageRepository;
 import jakarta.annotation.Nullable;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.imgscalr.Scalr;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -29,7 +24,6 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -160,7 +154,7 @@ public class S3ServiceImpl implements S3Service {
     @Override
     public String generatePresignedUrl(String key, Duration duration) {
         if (key == null || key.isBlank()) {
-            log.warn("Klucz obrazka jest pusty w bazie danych!");
+            log.warn("Image key is null or blank");
             return null;
         }
         PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(

--- a/services/main-api/src/main/resources/application.properties
+++ b/services/main-api/src/main/resources/application.properties
@@ -31,4 +31,4 @@ spring.rabbitmq.template.retry.enabled=true
 spring.rabbitmq.listener.simple.default-requeue-rejected=false
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=50MB
-
+allowed.interceptor.origins=http://localhost:5173


### PR DESCRIPTION
- Replaced SockJS/STOMP headers auth with Native WS + CookieHandshakeInterceptor
- Added CustomHandshakeHandler to resolve Principal from cookies
- Fixed CORS and CSRF for /ws endpoint
- Removed UserChannelInterceptor (simplified auth